### PR TITLE
feat: jump to workspace file with built-in go-to-definition feature

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,12 @@
+import type { ObjectProperty } from '@babel/types'
 import { useLogger } from 'reactive-vscode'
+import { Range, type TextDocument } from 'vscode'
 import { displayName } from './generated/meta'
 
 export const logger = useLogger(displayName)
+
+export function getNodeRange(doc: TextDocument, node: ObjectProperty, offset: number) {
+  const start = node.value.start! + offset + 1
+  const end = node.value.end! + offset - 1
+  return new Range(doc.positionAt(start), doc.positionAt(end))
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Added support to jump to workspace file with built-in go-to-definition feature in VSCode.
You can now open the workspace file by ctrl + clicking the `catalog:` string.

[video.webm](https://github.com/user-attachments/assets/f830b506-b257-4ceb-b8d7-41ce7d5aaa15)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
