### PR TITLE
Upload .vsix file to release page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 permissions:
   contents: write
+  actions: write
 
 on:
   push:
@@ -16,10 +17,32 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          registry-url: https://registry.npmjs.org/
+          cache: pnpm
 
       - run: npx changelogithub
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - run: pnpm install
+
+      - name: Generate .vsix file
+        run: pnpm package
+
+      - name: Upload .vsix to Release
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          ASSET_NAME="pnpm-catalog-lens-${VERSION}.vsix"
+
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          REPO="${{ github.repository }}"
+
+          gh release upload "$TAG_NAME" "./${ASSET_NAME}" --repo "$REPO" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "lint": "eslint .",
     "vscode:prepublish": "nr build",
     "publish": "vsce publish --no-dependencies",
-    "pack": "vsce package --no-dependencies",
+    "pack": "vsce pack --no-dependencies",
+    "package": "vsce package --no-dependencies",
     "test": "vitest",
     "typecheck": "tsc --noEmit",
     "release": "bumpp && nr publish"


### PR DESCRIPTION
### Description

This PR adds the ability to upload the .vsix file to the Release page. enabling local installation of the theme for VSCode forks like cursor and windsurf.
