### PR TITLE
feat: support yarn catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-Show versions inline for <a href="https://pnpm.io/catalogs" target="_blank">PNPM <code>catalog:</code> field.</a><br>
+Show versions inline for <a href="https://pnpm.io/catalogs" target="_blank">PNPM</a> and <a href="https://yarnpkg.com/features/catalogs" target="_blank">Yarn</a> <code>catalog:</code> fields.<br>
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "vscode": "^1.90.0"
   },
   "activationEvents": [
-    "workspaceContains:pnpm-workspace.yaml"
+    "workspaceContains:pnpm-workspace.yaml",
+    "workspaceContains:.yarnrc.yml"
   ],
   "contributes": {
     "commands": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,6 @@
-export const workspaceFileName = 'pnpm-workspace.yaml'
+export const WORKSPACE_FILES = {
+  PNPM: 'pnpm-workspace.yaml',
+  YARN: '.yarnrc.yml',
+} as const
+
 export const catalogPrefix = 'catalog:'

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,12 @@ import { computed, defineExtension, executeCommand, shallowRef, toValue as track
 import { ConfigurationTarget, languages, MarkdownString, Position, Range, Uri, window, workspace } from 'vscode'
 import { config } from './config'
 import { catalogPrefix } from './constants'
-import { PnpmWorkspaceManager } from './data'
+import { WorkspaceManager } from './data'
 import { commands } from './generated/meta'
 import { getCatalogColor, getNodeRange, logger } from './utils'
 
 const { activate, deactivate } = defineExtension(() => {
-  const manager = new PnpmWorkspaceManager()
+  const manager = new WorkspaceManager()
 
   const editor = useActiveTextEditor()
   const tick = shallowRef(0)
@@ -131,7 +131,7 @@ const { activate, deactivate } = defineExtension(() => {
 
     await Promise.all(props.map(async ({ node, catalog }) => {
       catalog = catalog || 'default'
-      const { version, definition } = await manager.resolveCatalog(
+      const { version, definition, manager: packageManager } = await manager.resolveCatalog(
         doc.value!,
         (node.key as StringLiteral).value,
         catalog,
@@ -154,7 +154,7 @@ const { activate, deactivate } = defineExtension(() => {
 
       const md = new MarkdownString()
       md.appendMarkdown([
-        `- PNPM Catalog: \`${catalog}\``,
+        `- ${packageManager} Catalog: \`${catalog}\``,
         versionPositionCommandUri ? `- Version: [${version}](${versionPositionCommandUri})` : `- Version: \`${version}\``,
       ].join('\n'))
       md.isTrusted = true


### PR DESCRIPTION
### Description
This PR adds support for [Yarn catalog feature](https://yarnpkg.com/features/catalogs) in addition to the existing PNPM catalog support. The extension now detects both `pnpm-workspace.yaml` and `.yarnrc.yml` files and can handle catalog references from both package managers.

**Key changes**
- Extended workspace detection to support both PNPM (pnpm-workspace.yaml) and Yarn (.yarnrc.yml) configurations
- Refactored code to be package manager agnostic by:
  - Renaming classes and interfaces to remove PNPM-specific naming
  - Adding workspace manager type detection
  - Updating hover information to display the correct package manager
- Added .yarnrc.yml to VSCode activation events
- Updated README to reflect support for both PNPM and Yarn catalogs

**What this solves**
- Enables the extension to work with Yarn workspaces that use the catalog feature
- Provides consistent catalog version inline display for both PNPM and Yarn users
- Maintains backward compatibility with existing PNPM workspace setups

### Additional context

Currently, the extension name is "PNPM Catalog Lens" and extension configuration keys are also handled as `pnpmCatalogLens.*`.
This PR intentionally did not modify these aspects, and no additional options, such as `enableYarnCatalog`, were added.
If this PR gets merged, the extension naming could also be changed to allow more diverse users to discover and utilize this extension.
