### PR TITLE
fix: rolldown build with treeshake

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --external vscode --format cjs",
+    "build": "tsdown",
     "dev": "nr build --watch",
     "prepare": "nr update",
     "update": "vscode-ext-gen --output src/generated/meta.ts --scope pnpmCatalogLens",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: 'src/index.ts',
+  format: 'cjs',
+  external: ['vscode'],
+
+  // FIXME: https://github.com/antfu/vscode-pnpm-catalog-lens/issues/23
+  treeshake: false,
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

I'm not sure if this PR is the best way to fix it. I noticed that the issue doesn't occur in `rolldown@1.0.0-beta-38`, but it does appear in `rolldown-1.0.0-beta-39`.


Normally, the bundled output retains the `exports.default` value.

<img width="737" height="471" alt="image" src="https://github.com/user-attachments/assets/8cbbe96a-e312-4550-b3db-e115b9a10c67" />

<img width="707" height="302" alt="image" src="https://github.com/user-attachments/assets/5723615c-7aea-46ed-8474-0a63daf9ac02" />

but it gets removed when `treeshake` is enabled.

<img width="930" height="656" alt="image" src="https://github.com/user-attachments/assets/be305b7b-f3a3-4402-a658-305ac59e20f2" />


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

https://github.com/antfu/vscode-pnpm-catalog-lens/issues/23

### Additional context

The same issue was also fixed in this https://github.com/antfu/vscode-pnpm-catalog-lens/pull/25 by rolling back the `rolldown` version.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
